### PR TITLE
Add support for URI credentials

### DIFF
--- a/lib/kiwi_config.rb
+++ b/lib/kiwi_config.rb
@@ -11,10 +11,13 @@ class KiwiConfig
     repo_uri = []
     xml.elements.each("*/repository") do |repo|
       repo_type = repo.attributes["type"]
+      user = repo.attributes["username"]
+      pass = repo.attributes["password"]
       repo.elements.each("source") do |element|
         source_path = element.attributes["path"].gsub(/\?.*/,"")
         repo_uri << KiwiUri.translate(
-          :name => source_path, :repo_type => repo_type
+          :name => source_path, :repo_type => repo_type,
+          :user => user, :pass => pass
         )
       end
     end

--- a/lib/repo_uri.rb
+++ b/lib/repo_uri.rb
@@ -1,10 +1,12 @@
 class RepoUri
-  attr_reader :name, :type, :location, :repo_type
+  attr_reader :name, :type, :location, :repo_type, :user, :pass
   attr_reader :allowed_local_types, :allowed_remote_types
   attr_reader :mount_point
 
   def initialize(args)
     @name = args[:name]
+    @user = args[:user]
+    @pass = args[:pass]
     @repo_type = args[:repo_type]
     set_uri_type_and_location
 


### PR DESCRIPTION
If an URL of the form "uri://user:pass@location" is provided the
credentials information was not properly handled for curl and
ruby's openURI implementation